### PR TITLE
fix: PHP 8.0+ compat - replace Override attribute with ReturnTypeWillChange

### DIFF
--- a/classes/abstract_processor.php
+++ b/classes/abstract_processor.php
@@ -79,7 +79,7 @@ abstract class abstract_processor extends process_base {
      */
     abstract protected function handle_api_success(ResponseInterface $response): array;
 
-    #[\Override]
+    #[\ReturnTypeWillChange]
     protected function query_ai_api(): array {
 
         // Create the request object.

--- a/classes/provider.php
+++ b/classes/provider.php
@@ -102,7 +102,7 @@ class provider extends \core_ai\provider {
             ->withAddedHeader('x-goog-api-key', $this->apikey);
     }
 
-    #[\Override]
+    #[\ReturnTypeWillChange]
     public function is_request_allowed(aiactions\base $action): array|bool {
         $ratelimiter = \core\di::get(rate_limiter::class);
         $component = \core\component::get_component_from_classname(get_class($this));


### PR DESCRIPTION
## Summary

Replaces `#[\Override]` with `#[\ReturnTypeWillChange]` in two files for PHP 8.0-8.2 compatibility.

### Problem

`#[\Override]` was introduced in PHP 8.3, but Moodle 4.5 supports PHP 8.0+. Sites running PHP 8.0, 8.1, or 8.2 get a fatal error when the attribute is encountered.

### Fix

| File | Change |
|------|--------|
| `classes/abstract_processor.php` | `#[\Override]` replaced on `query_ai_api()` |
| `classes/provider.php` | `#[\Override]` replaced on `is_request_allowed()` |

`#[\ReturnTypeWillChange]` is available in PHP 8.0+ and serves the same purpose for methods that override parent signatures with different return types.

### Compatibility
- PHP 8.0+
- PHP 8.3+ (still works)
- Moodle 4.5+

### Testing
- [x] Only 2 lines changed - pure attribute replacement
- [x] No logic changes
- [x] Diff is minimal and reviewable
